### PR TITLE
Add non-exit check to challenge

### DIFF
--- a/contracts/Erdstall.sol
+++ b/contracts/Erdstall.sol
@@ -111,6 +111,7 @@ contract Erdstall {
     function challenge(Balance calldata balance, bytes calldata sig) external onlyAlive {
         require(balance.account == msg.sender, "challenge: wrong sender");
         require(balance.epoch == sealedEpoch(), "challenge: wrong epoch");
+        require(!balance.exit, "challenge: exit proof");
         verifyBalance(balance, sig);
 
         registerChallenge(balance.value);


### PR DESCRIPTION
Without this check, users could challenge with their exit proofs as well
as withdraw, leaving the operator with an open challenge that cannot be
answered, since no balance proofs are generated by the epoch in the
following epochs.