### PR TITLE
PerunArt baseURI, idempotent token(type) registration, catch withdrawal reverts

### DIFF
--- a/contracts/ERC721Holder.sol
+++ b/contracts/ERC721Holder.sol
@@ -30,7 +30,7 @@ contract ERC721Holder is TokenHolder {
     {
         IERC721 token = IERC721(_token);
         for (uint i=0; i < ids.length; i++) {
-            token.safeTransferFrom(from, to, ids[i]);
+            token.transferFrom(from, to, ids[i]);
         }
     }
 }
@@ -57,7 +57,7 @@ contract ERC721MintableHolder is ERC721Holder {
     function transferOrMint(IERC721Minter token, address to, uint256 id) internal {
         try token.ownerOf(id) returns (address owner) {
             if (owner == address(this)) {
-                token.safeTransferFrom(address(this), to, id);
+                token.transferFrom(address(this), to, id);
             }
             // else token exists, but owned by someone else, so we skip
             // minting it. In a production setting, there has to be some

--- a/contracts/PerunArt.sol
+++ b/contracts/PerunArt.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 contract PerunArt is ERC721 {
+    string private baseURI;
     address public immutable owner;
     mapping(address => bool) minters;
 
@@ -25,20 +26,26 @@ contract PerunArt is ERC721 {
       * Additional minters can later be added by the owner=deployer using
       * `addMinter`.
       */
-    constructor(string memory _name, string memory _symbol, address[] memory _minters)
+    constructor(string memory _name, string memory _symbol,
+                string memory _uriBase, address[] memory _minters)
     ERC721(_name, _symbol)
     {
+        baseURI = _uriBase;
         owner = msg.sender;
         for (uint i=0; i < _minters.length; i++) {
             minters[_minters[i]] = true;
         }
     }
 
+    function _baseURI() internal view override returns (string memory) {
+        return baseURI;
+    }
+
     function addMinter(address _minter) external onlyOwner {
             minters[_minter] = true;
     }
 
-    function mint(address to, uint256 id) public onlyMinter {
+    function mint(address to, uint256 id) external onlyMinter {
         _mint(to, id);
     }
 }

--- a/contracts/PerunArt.sol
+++ b/contracts/PerunArt.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract PerunArt is ERC721 {
     string private baseURI;
@@ -30,7 +31,8 @@ contract PerunArt is ERC721 {
                 string memory _uriBase, address[] memory _minters)
     ERC721(_name, _symbol)
     {
-        baseURI = _uriBase;
+        string memory thisAddr = Strings.toHexString(uint(uint160(address(this))), 20);
+        baseURI = string(abi.encodePacked(_uriBase, thisAddr, "/"));
         owner = msg.sender;
         for (uint i=0; i < _minters.length; i++) {
             minters[_minters[i]] = true;

--- a/contracts/PerunArt.sol
+++ b/contracts/PerunArt.sol
@@ -45,7 +45,7 @@ contract PerunArt is ERC721 {
             minters[_minter] = true;
     }
 
-    function mint(address to, uint256 id) external onlyMinter {
+    function mint(address to, uint256 id) external virtual onlyMinter {
         _mint(to, id);
     }
 }

--- a/contracts/lib/Bytes.sol
+++ b/contracts/lib/Bytes.sol
@@ -5,6 +5,14 @@ pragma solidity ^0.8.0;
 // Minimal bytes library, inspired by
 // https://github.com/GNSPS/solidity-bytes-utils
 library Bytes {
+    function areEqual(bytes memory x, bytes memory y) internal pure returns (bool) {
+        return (x.length == y.length) && (keccak256(x) == keccak256(y));
+    }
+
+    function areEqualStr(string memory x, string memory y) internal pure returns (bool) {
+        return areEqual(bytes(x), bytes(y));
+    }
+
     function asUint256(bytes memory x) internal pure returns (uint256 r) {
         require(x.length == 32, "Bytes: not length 32");
         assembly {

--- a/contracts/testing/RevertToken.sol
+++ b/contracts/testing/RevertToken.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "../PerunArt.sol";
+
+contract RevertToken is PerunArt {
+    uint immutable revertModulus;
+
+    modifier checkRevert(uint256 id) {
+        require(id % revertModulus != 0, "revert id");
+        _;
+    }
+
+    constructor(string memory _baseURI, address[] memory _minters, uint _revertModulus)
+    PerunArt("Revert", "RVT", _baseURI, _minters)
+    {
+        revertModulus = _revertModulus;
+    }
+
+    function mint(address to, uint256 id) external override onlyMinter checkRevert(id) {
+        _mint(to, id);
+    }
+}

--- a/test/erdstall.ts
+++ b/test/erdstall.ts
@@ -178,7 +178,7 @@ describe("Erdstall", () => {
 
     for (const id of tknIds) {
       expect(await prnArt.ownerOf(id)).to.equal(aliceAddr);
-      expect(await prnArt.tokenURI(id)).to.equal(`${BASE_URL}${id}`);
+      expect(await prnArt.tokenURI(id)).to.equal(`${BASE_URL}${prnArt.address.toLowerCase()}/${id}`);
     }
   });
 

--- a/test/erdstall.ts
+++ b/test/erdstall.ts
@@ -8,8 +8,7 @@ import {
 import chai from "chai";
 import { solidity } from "ethereum-waffle";
 
-import * as test from "@polycrypt/erdstall/test";
-import { Balance, BalanceProof, BalanceProofs } from "@polycrypt/erdstall/api/responses";
+import { Balance } from "@polycrypt/erdstall/api/responses";
 import { Address } from "@polycrypt/erdstall/ledger";
 import { Amount, Assets, Tokens } from "@polycrypt/erdstall/ledger/assets";
 
@@ -29,7 +28,7 @@ const { expect } = chai;
 describe("Erdstall", () => {
   const EPOCHD = 12;
   const TEE = 0, OP = 1, ALICE = 2, BOB = 3;
-  const rng = test.NewPrng();
+  const BASE_URL = "https://api.erdstall.dev/token/";
   const provider = waffle.provider;
 
   let prn: PerunToken;
@@ -119,7 +118,7 @@ describe("Erdstall", () => {
 
     // 3. Deploy PerunArt with holder as minter
     const prnArtFactory = (await ethers.getContractFactory("PerunArt", accounts[OP])) as PerunArt__factory;
-    prnArt = await prnArtFactory.deploy("PerunArt", "PART", [erc721Holder.address]);
+    prnArt = await prnArtFactory.deploy("PerunArt", "PART", BASE_URL, [erc721Holder.address]);
     await prnArt.deployed();
 
     // 4. Register PerunArt token contact
@@ -175,7 +174,9 @@ describe("Erdstall", () => {
       .to.emit(erdstall, "Withdrawn"))
       .to.changeTokenBalance(prn, accounts[ALICE], amount);
 
-    for (const id of tknIds)
+    for (const id of tknIds) {
       expect(await prnArt.ownerOf(id)).to.equal(aliceAddr);
+      expect(await prnArt.tokenURI(id)).to.equal(`${BASE_URL}${id}`);
+    }
   });
 });


### PR DESCRIPTION
- PerunArt: Set baseURI in constructor
- lib/Bytes: Add areEqual(Str) functions for bytes/string equality check
- Erdstall: Make token (type) registration idempotent
- Erdstall: Catch individual token transfer exceptions during withdrawals
- test: Test reverts during withdrawals
